### PR TITLE
Spear throwing time

### DIFF
--- a/game.ch8
+++ b/game.ch8
@@ -675,7 +675,8 @@
 
 	i := spear1
 	load a_spearX - a_spearY
-	f_drawSpear
+	# only need to update spears that aren't stuck
+	if a_spearSpeedX != 0 then f_drawSpear
 ;
 
 : f_redrawSprites
@@ -686,24 +687,32 @@
 
 	i := spear1
 	load a_spearX - a_spearY
-	f_drawSpear
+	# only need to update spears that aren't stuck
+	if a_spearSpeedX != 0 then f_drawSpear
 ;
 
 : f_scroll
 	# scrolls exactly one row
 	# a bit inefficient but I like how it looks when you ascend faster than the scrolling
 	push
+
 	i := player
 	load a_playerY
-
 	a_playerY += 1
+	i := player
+	save a_playerY
+
+	i := spear1
+	load a_spearY
+	a_spearY += 1
+	i := spear1
+	save a_spearY
+
 	plane 3
 	scroll-down 1
 	plane 1
 	f_drawMap
 
-	i := player
-	save a_playerY
 	pop
 ;
 

--- a/game.ch8
+++ b/game.ch8
@@ -19,8 +19,8 @@
 
 :alias a_playerX             v0
 :alias a_playerY             v1
-:alias a_playerPrevX         v2
-:alias a_playerPrevY         v3
+:alias a_playerDirection     v2
+:alias a_playerWild          v3
 :alias a_playerSpeedX        v4
 :alias a_playerSpeedY        v5
 :alias a_playerJumpAvailable v6
@@ -32,10 +32,11 @@
 : playerY
 	56
 
-: playerPrevCoords
-: playerPrevX
-	5
-: playerPrevY
+: playerDirection
+	# 0 for facing left, 1 for facing right
+	1
+: playerWild
+	# this space reserved for whatever is needed
 	0
 
 : playerSpeed
@@ -157,9 +158,6 @@
 	i := player
 	load v6
 
-	# store the previous x position in case of collision
-	a_playerPrevX := a_playerX
-
 : j_input_jump
 	a_temp := 5 # W
 	if a_temp -key then jump j_input_jumpRelease
@@ -197,6 +195,7 @@
 	a_temp := vb
 	a_temp -= va
 	if a_playerSpeedX == a_temp then a_playerSpeedX := vb
+	a_playerDirection := 0
 	jump j_input_save
 
 : j_input_right
@@ -206,6 +205,7 @@
 	a_temp := c_maxSpeed
 	a_temp += va
 	if a_playerSpeedX == a_temp then a_playerSpeedX := c_maxSpeed
+	a_playerDirection := 1
 	jump j_input_save
 
 : j_input_none
@@ -265,11 +265,6 @@
 : f_drawAmy
 	i := amy
 	sprite a_playerX a_playerY 3
-;
-
-: f_drawAmyPrev
-	i := amy
-	sprite a_playerPrevX a_playerPrevY 3
 ;
 
 : f_checkCollisionH

--- a/game.ch8
+++ b/game.ch8
@@ -51,6 +51,131 @@
 
 #################################
 #
+#  Spear Data
+#
+
+:const c_spearGravityStrength 1
+:const c_spearInitialX        5
+:const c_spearInitialY        -4
+:const c_spearCooldown        100 #  5 seconds @ 20 fps
+:const c_spearTime            200 # 10 seconds @ 20 fps
+
+:alias a_spearX      v0
+:alias a_spearY      v1
+:alias a_spearSpeedX v2
+:alias a_spearSpeedY v3
+:alias a_spearTimer  v4
+
+: spear
+	0b111
+
+: spearCount
+	0
+
+: spearCooldown
+	0
+
+: spear1
+: spear1Location
+: spear1X
+	0
+: spear1Y
+	0
+: spear1SpeedX
+	0
+: spear1SpeedY
+	0
+: spear1Timer
+	0
+
+: spear2
+: spear2Location
+: spear2X
+	0
+: spear2Y
+	0
+: spear2SpeedX
+	0
+: spear2SpeedY
+	0
+: spear2Timer
+	0
+
+: spear3
+: spear3Location
+: spear3X
+	0
+: spear3Y
+	0
+: spear3SpeedX
+	0
+: spear3SpeedY
+	0
+: spear3Timer
+	0
+
+: f_drawSpear
+	i := spear
+	sprite a_spearX a_spearY 1
+;
+
+: f_throwSpear
+	push
+
+	# set the spear cooldown
+	i  := spearCooldown
+	v0 := c_spearCooldown
+	save v0
+
+	# initialize a spear at the player's location
+	i := player
+	load a_playerX - a_playerDirection
+	va := a_playerX
+	vb := a_playerY
+	vc := a_playerDirection
+
+	if vc == 0 then va += -2
+	if vc == 1 then va +=  3
+
+	a_spearX := va
+	a_spearY := vb
+
+	# initialize spear speed
+	a_spearSpeedX := 0
+	a_temp := c_spearInitialX
+	if vc == 0 then a_spearSpeedX -= a_temp
+	if vc == 1 then a_spearSpeedX += a_temp
+
+	a_spearSpeedY := c_spearInitialY
+	a_spearTimer  := c_spearTime
+
+	# save spear
+	i := spear1
+	save v5
+
+	f_drawSpear
+
+	pop
+;
+
+: f_moveSpears
+	push
+	i := spear1
+	load v4
+
+	a_spearX += a_spearSpeedX
+	a_spearSpeedY += c_spearGravityStrength
+	a_spearY += a_spearSpeedY
+	f_drawSpear
+
+	i := spear1
+	save v4
+	pop
+;
+
+
+#################################
+#
 #  Level Data
 #
 
@@ -111,18 +236,14 @@
 	f_setup
 	loop
 		f_checkScrolling
+		f_moveSpears
 		f_gravity
 		f_checkCollisionV
 		f_input
 		f_checkCollisionH
+		f_tickCooldowns
 		f_delayFPS
-
-		# undraw player before next movement
-		#   this would be nicer if it could be easily moved into
-		#   the movement logic
-		i := player
-		load v2
-		f_drawAmy
+		f_clearSprites
 	again
 ;
 
@@ -157,6 +278,18 @@
 	push
 	i := player
 	load v6
+
+: j_input_spear
+	a_temp := 6 # E
+	if a_temp -key then jump j_input_jump
+
+	# don't throw a spear if it's still on cooldown
+	i := spearCooldown
+	load va - va
+	if va != 0 then jump j_input_jump
+
+	f_throwSpear
+	jump j_input_jump
 
 : j_input_jump
 	a_temp := 5 # W
@@ -435,6 +568,18 @@
 	pop
 ;
 
+: f_tickCooldowns
+	push
+
+	i := spearCooldown
+	load v0
+	if v0 != 0 then v0 += -1
+	i := spearCooldown
+	save v0
+
+	pop
+;
+
 : f_delayFPS
 	# delay loop to lock framerate and prevent flicker
 	loop
@@ -442,6 +587,17 @@
 		if vf != 0 then again
 	vf := 3
 	delay := vf
+;
+
+: f_clearSprites
+	# undraw all dynamic sprites before the screen scroll
+	i := player
+	load a_playerX - a_playerY
+	f_drawAmy
+
+	i := spear1
+	load a_spearX - a_spearY
+	f_drawSpear
 ;
 
 : f_scroll

--- a/game.ch8
+++ b/game.ch8
@@ -48,6 +48,15 @@
 : playerJumpAvailable
 	0
 
+: f_drawAmy
+	# this function does NOT use push/pop because that affects vf and
+	# drawing is used for collision detection. it instead relies on
+	# a_playerX and a_playerY being set appropriately by the calling
+	# function
+	i := amy
+	sprite a_playerX a_playerY 3
+;
+
 
 #################################
 #
@@ -119,6 +128,10 @@
 	0
 
 : f_drawSpear
+	# this function does NOT use push/pop because that affects vf and
+	# drawing is used for collision detection. it instead relies on
+	# a_playerX and a_playerY being set appropriately by the calling
+	# function
 	i := spear
 	sprite a_spearX a_spearY 1
 ;
@@ -247,6 +260,34 @@
 	0
 : jumpKeyReleased
 	1
+
+: f_jumpKeyPressed
+	push
+
+	v0 := 1
+	v1 := 0
+	i  := jumpKeyData
+	save v1
+
+	pop
+;
+
+: f_jumpKeyReleased
+	push
+
+	i := jumpKeyData
+	load v1
+
+	if v0 != 1 then jump f_jumpKeyReleased_return
+
+	v0 := 0
+	v1 := 1
+	i := jumpKeyData
+	save v1
+
+: f_jumpKeyReleased_return
+	pop
+;
 
 
 #################################
@@ -387,40 +428,52 @@
 	pop
 ;
 
-: f_jumpKeyPressed
+: f_gravity
 	push
 
-	v0 := 1
-	v1 := 0
-	i  := jumpKeyData
-	save v1
+	# player gravity
+	i := player
+	load v6
+	a_playerSpeedY += c_gravityStrength
+	i := player
+	save v6
+
+	# spear gravity
+	i := spear1
+	load v4
+	a_spearSpeedY += c_spearGravityStrength
+	if a_spearSpeedX == 0 then a_spearSpeedY := 0  # stick spear in walls
+	i := spear1
+	save v4
 
 	pop
 ;
 
-: f_jumpKeyReleased
-	push
 
-	i := jumpKeyData
-	load v1
 
-	if v0 != 1 then jump f_jumpKeyReleased_return
+#################################
+#
+#  Collision Detection
+#
 
-	v0 := 0
-	v1 := 1
-	i := jumpKeyData
-	save v1
-
-: f_jumpKeyReleased_return
-	pop
-;
-
-# this function does NOT use push/pop because that affects vf and
-# drawing is used for collision detection. it instead relies on
-# a_playerX and a_playerY being set appropriately by the calling function
-: f_drawAmy
+: spriteTable
 	i := amy
-	sprite a_playerX a_playerY 3
+	sprite a_spriteX a_spriteY 3
+	pop
+	return
+
+	i := spear
+	sprite a_spriteX a_spriteY 1
+	pop
+	return
+;
+
+: f_checkCollision_drawSprite
+	push
+	v0 <<= a_spriteTableOffset
+	v0 <<= v0
+	v0 <<= v0
+	jump0 spriteTable
 ;
 
 : f_checkCollisionH
@@ -516,29 +569,29 @@
 
 	# store x-offset from player origin to check foot collision
 	#   (based on direction player is moving)
-	if a_temp ==  1 then v2 :=  0
-	if a_temp == -1 then v2 := -1
+	if a_temp ==  1 then a_temp1 :=  0
+	if a_temp == -1 then a_temp1 := -1
 
 	# only do stepping logic is player is on the ground
+	#   - this reference to a_playerJumpAvailable is the only reason
+	#     the arguments for collision detection start at v7...
 	if a_playerJumpAvailable != 2 then jump j_checkCollisionH_checkStep_false
 
 	# draw dot on ground at player's foot
 	#   va differs based on direction to check left or right
-	v0 := a_spriteX
-	v0 += v2
-	v1 := a_spriteY
-	v1 += 2
+	a_spriteX += a_temp1
+	a_spriteY += 2
 	i  := dot
-	sprite v0 v1 1
-	sprite v0 v1 1
+	sprite a_spriteX a_spriteY 1
+	sprite a_spriteX a_spriteY 1
 
 	# player has hit a wall that does not connect to the ground
 	if vf != 0 then jump j_checkCollisionH_checkStep_false
 
 	# draw dot 1 higher
-	v1 += -1
-	sprite v0 v1 1
-	sprite v0 v1 1
+	a_spriteY += -1
+	sprite a_spriteX a_spriteY 1
+	sprite a_spriteX a_spriteY 1
 
 	# the ground the player is walking into is two blocks high
 	if vf == 0 then jump j_checkCollisionH_checkStep_false
@@ -549,47 +602,6 @@
 
 : j_checkCollisionH_checkStep_false
 	vf := 0
-;
-
-: f_checkCollision_drawSprite
-	push
-	v0 <<= a_spriteTableOffset
-	v0 <<= v0
-	v0 <<= v0
-	jump0 spriteTable
-;
-
-: spriteTable
-	i := amy
-	sprite a_spriteX a_spriteY 3
-	pop
-	return
-
-	i := spear
-	sprite a_spriteX a_spriteY 1
-	pop
-	return
-;
-
-: f_gravity
-	push
-
-	# player gravity
-	i := player
-	load v6
-	a_playerSpeedY += c_gravityStrength
-	i := player
-	save v6
-
-	# spear gravity
-	i := spear1
-	load v4
-	a_spearSpeedY += c_spearGravityStrength
-	if a_spearSpeedX == 0 then a_spearSpeedY := 0  # stick spear in walls
-	i := spear1
-	save v4
-
-	pop
 ;
 
 : f_checkCollisionV

--- a/game.ch8
+++ b/game.ch8
@@ -1,9 +1,9 @@
 :const c_jumpHeight       -14
 :const c_doubleJumpHeight -8
-:const c_maxSpeed          4
-:const c_runAccelerate     4
-:const c_airDecelerate     4
-:const c_groundDecelerate  4
+:const c_maxSpeed          1
+:const c_runAccelerate     1
+:const c_airDecelerate     1
+:const c_groundDecelerate  1
 :const c_gravityStrength   2
 
 :alias a_counter    vd
@@ -401,101 +401,133 @@
 ;
 
 : f_checkCollisionH
-	:alias a_partialDX v7
-
 	push
+
 	i := player
 	load v6
 
-	# collide slowly
-	#   undraw amy, redraw amy one pixel in the x direction and see if she
-	#   collides. if she ever does, revert back one position and exit.
-	if a_playerSpeedX < 128 begin
-		a_temp :=  1
-		a_partialDX >>= a_playerSpeedX
-		a_partialDX >>= a_partialDX
-	end
+	# parameters for collision detection
+	v7 := a_playerX
+	v8 := a_playerY
+	v9 := a_playerSpeedX
+	va := 0
+	f_checkCollisionH_detectCollision
 
-	if a_playerSpeedX > 128 begin
-		a_temp := -1
-		a_partialDX >>= a_playerSpeedX
-		a_partialDX >>= a_partialDX
-		a_partialDX += 0b11000000
-	end
-
-	if a_partialDX == 0 then jump j_checkCollisionH_return
-
-	loop	
-		f_drawAmy # undraw
-		a_partialDX -= a_temp
-		a_playerX += a_temp
-		f_drawAmy # redraw
-		if vf != 0 begin
-			# undraw player
-			f_drawAmy
-
-			f_checkStep
-			if vf == 1 then jump j_checkCollisionH_step
-
-			# if not a step, force the player back
-			a_playerSpeedX := 0
-			a_playerX -= a_temp
-			f_drawAmy
-			jump j_checkCollisionH_return
-
-			: j_checkCollisionH_step
-			# redraw player 1 higher
-			a_playerY += -1
-			f_drawAmy
-		end
-	if a_partialDX != 0 then again
-
-: j_checkCollisionH_return
+	a_playerX := v7
+	a_playerY := v8
+	a_playerSpeedX := v9
 	i := player
 	save v6
+
 	pop
 ;
 
-: f_checkStep
+: f_checkCollisionH_detectCollision
+	# collide slowly
+	#   undraw sprite and redraw one pixel in the x direction and see if
+	#   it collides. if it ever does, revert back one position and exit.
+	#
+	# input parameters:
+	:alias a_spriteX           v7
+	:alias a_spriteY           v8
+	:alias a_spriteSpeedX      v9
+	:alias a_spriteTableOffset va
+
+	if a_spriteSpeedX == 0  then return
+	if a_spriteSpeedX < 128 then a_temp :=  1
+	if a_spriteSpeedX > 128 then a_temp := -1
+
+	a_counter := a_spriteSpeedX
+	loop	
+		f_checkCollisionH_drawSprite # undraw
+		a_counter -= a_temp
+		a_spriteX += a_temp
+		f_checkCollisionH_drawSprite # redraw
+		if vf != 0 begin
+			f_checkCollisionH_drawSprite
+
+			push
+			f_checkCollisionH_checkStep
+			if vf == 1 begin
+				pop
+				jump j_checkCollisionH_detectCollision_step
+			end
+			pop
+
+			# if not a step, force the sprite back
+			a_spriteSpeedX := 0
+			a_spriteX -= a_temp
+			f_checkCollisionH_drawSprite
+			return
+
+			: j_checkCollisionH_detectCollision_step
+			# redraw player 1 higher
+			a_spriteY += -1
+			f_checkCollisionH_drawSprite
+		end
+	if a_counter != 0 then again
+;
+
+: f_checkCollisionH_checkStep
 	# sets vf to 1 if the player has hit a step, else sets vf to 0
 	# assumes player position is loaded into a_playerX and a_playerY and
 	# player direction is stored in a_temp
 
 	# store x-offset from player origin to check foot collision
 	#   (based on direction player is moving)
-	if a_temp ==  1 then va :=  0
-	if a_temp == -1 then va := -1
+	if a_temp ==  1 then v2 :=  0
+	if a_temp == -1 then v2 := -1
 
 	# only do stepping logic is player is on the ground
-	if a_playerJumpAvailable != 2 then jump j_checkStep_false
+	if a_playerJumpAvailable != 2 then jump j_checkCollisionH_checkStep_false
 
 	# draw dot on ground at player's foot
 	#   va differs based on direction to check left or right
-	v8 := a_playerX
-	v8 += va
-	v9 := a_playerY
-	v9 += 2
+	v0 := a_spriteX
+	v0 += v2
+	v1 := a_spriteY
+	v1 += 2
 	i  := dot
-	sprite v8 v9 1
-	sprite v8 v9 1
+	sprite v0 v1 1
+	sprite v0 v1 1
 
 	# player has hit a wall that does not connect to the ground
-	if vf != 0 then jump j_checkStep_false
+	if vf != 0 then jump j_checkCollisionH_checkStep_false
 
 	# draw dot 1 higher
-	v9 += -1
-	sprite v8 v9 1
-	sprite v8 v9 1
+	v1 += -1
+	sprite v0 v1 1
+	sprite v0 v1 1
 
 	# the ground the player is walking into is two blocks high
-	if vf == 0 then jump j_checkStep_false
+	if vf == 0 then jump j_checkCollisionH_checkStep_false
 
-: j_checkStep_true
+: j_checkCollisionH_checkStep_true
 	vf := 1
 	return
 
-: j_checkStep_false
+: j_checkCollisionH_checkStep_false
 	vf := 0
+;
+
+: f_checkCollisionH_drawSprite
+	push
+	v0 <<= a_spriteTableOffset
+	v0 <<= v0
+	v0 <<= v0
+	jump0 spriteTable
+;
+
+: spriteTable
+	i := amy
+	sprite a_spriteX a_spriteY 3
+	pop
+	return
+
+	i := spear
+	sprite a_spriteX a_spriteY 1
+	pop
+	return
 ;
 
 : f_gravity

--- a/game.ch8
+++ b/game.ch8
@@ -57,8 +57,8 @@
 :const c_spearGravityStrength 1
 :const c_spearInitialX        5
 :const c_spearInitialY        -4
-:const c_spearCooldown        100 #  5 seconds @ 20 fps
-:const c_spearTime            200 # 10 seconds @ 20 fps
+:const c_spearCooldown        40  #  2 seconds @ 20 fps
+:const c_spearTime            120 #  6 seconds @ 20 fps
 
 :alias a_spearX      v0
 :alias a_spearY      v1

--- a/game.ch8
+++ b/game.ch8
@@ -58,13 +58,12 @@
 :const c_spearInitialX        5
 :const c_spearInitialY        -4
 :const c_spearCooldown        40  #  2 seconds @ 20 fps
-:const c_spearTime            120 #  6 seconds @ 20 fps
 
 :alias a_spearX      v0
 :alias a_spearY      v1
 :alias a_spearSpeedX v2
 :alias a_spearSpeedY v3
-:alias a_spearTimer  v4
+:alias a_spearActive v4
 
 : spear
 	0b111
@@ -74,6 +73,11 @@
 
 : spearCooldown
 	0
+
+: spearTable
+	i := spear1	return
+	i := spear2	return
+	i := spear3	return
 
 : spear1
 : spear1Location
@@ -85,7 +89,7 @@
 	0
 : spear1SpeedY
 	0
-: spear1Timer
+: spear1Active
 	0
 
 : spear2
@@ -98,7 +102,7 @@
 	0
 : spear2SpeedY
 	0
-: spear2Timer
+: spear2Active
 	0
 
 : spear3
@@ -111,12 +115,18 @@
 	0
 : spear3SpeedY
 	0
-: spear3Timer
+: spear3Active
 	0
 
 : f_drawSpear
 	i := spear
 	sprite a_spearX a_spearY 1
+;
+
+: f_selectSpear
+	# accepts a jump table offset in a_temp
+	v0 := a_temp
+	jump0 spearTable
 ;
 
 : f_throwSpear
@@ -141,7 +151,7 @@
 
 	a_spearSpeedX := a_temp
 	a_spearSpeedY := c_spearInitialY
-	a_spearTimer  := c_spearTime
+	a_spearActive := 1
 
 	f_drawSpear
 	if vf != 1 then jump j_throwSpear_succeed
@@ -150,9 +160,10 @@
 	jump j_throwSpear_fail
 
 : j_throwSpear_succeed
-	# save spear
+	f_queue_spears
+	# save new spear as spear 1
 	i := spear1
-	save v5
+	save v4
 
 	# set the spear cooldown
 	i  := spearCooldown
@@ -160,6 +171,28 @@
 	save v0
 
 : j_throwSpear_fail
+	pop
+;
+
+: f_queue_spears
+	push
+
+	# despawn spear3
+	i := spear3
+	load v4
+	if a_spearActive == 1 then f_drawSpear
+
+	# push spears down the queue
+	i := spear2
+	load v4
+	i := spear3
+	save v4
+
+	i := spear1
+	load v4
+	i := spear2
+	save v4
+
 	pop
 ;
 
@@ -581,19 +614,37 @@
 	# check spear collisions
 	i := spear1
 	load v4
+	if a_spearActive != 1 then jump j_checkCollisionV_return
 
 	v7 := a_spearX
 	v8 := a_spearY
 	v9 := a_spearSpeedY
 	va := 1
 	f_checkCollisionV_detectCollision
-
+	a_temp   := vf
 	a_spearX := v7
 	a_spearY := v8
 	a_spearSpeedY := v9
+
+	# if the spear wraps around vertically, destroy it
+	if a_spearY < 64 then jump j_checkCollisionV_spearSlide
+	a_spearActive := 0
+	f_drawSpear
+	jump j_checkCollisionV_spearSave
+
+: j_checkCollisionV_spearSlide
+	# if the spear "hits" the top of the screen via wraparound,
+	# it's fallen off and should be despawned
+	if a_temp == 0 then jump j_checkCollisionV_spearSave
+	if a_spearY != 63 then jump j_checkCollisionV_spearSave
+	a_spearActive := 0
+	f_drawSpear
+
+: j_checkCollisionV_spearSave
 	i := spear1
 	save v4
 
+: j_checkCollisionV_return
 	pop
 ;
 
@@ -601,6 +652,8 @@
 	# collide slowly
 	#   undraw sprite and redraw one pixel in the x direction and see if
 	#   it collides. if it ever does, revert back one position and exit.
+	#
+	#   sets vf to 0 if there is no collision, sets vf to 1 if there is
 	#
 	# input parameters:
 	:alias a_spriteX           v7
@@ -631,7 +684,7 @@
 		a_partialDY += 0b11000000
 	end
 	
-	if a_partialDY == 0 then return
+	if a_partialDY == 0 then jump j_checkCollisionV_detectCollision_false
 
 	loop	
 		f_checkCollision_drawSprite
@@ -646,9 +699,16 @@
 			f_checkCollision_drawSprite
 			a_spriteY -= a_temp
 			f_checkCollision_drawSprite
-			return
+			jump j_checkCollisionV_detectCollision_true
 		end
 	if a_partialDY != 0 then again
+
+: j_checkCollisionV_detectCollision_false
+	vf := 0
+	return
+
+: j_checkCollisionV_detectCollision_true
+	vf := 1
 ;
 
 : f_tickCooldowns
@@ -693,7 +753,7 @@
 	i := spear1
 	load a_spearX - a_spearY
 	# only need to update spears that aren't stuck
-	if a_spearSpeedX != 0 then f_drawSpear
+	if a_spearActive == 1 then f_drawSpear
 ;
 
 : f_scroll
@@ -707,11 +767,23 @@
 	i := player
 	save a_playerY
 
-	i := spear1
-	load a_spearY
-	a_spearY += 1
-	i := spear1
-	save a_spearY
+	a_counter := 3
+	a_temp    := 0
+	loop
+		f_selectSpear
+		load v4
+
+		a_spearY += 1
+		if a_spearY > 63 then a_spearActive := 0
+		a_temp1 := v0
+
+		f_selectSpear
+		v0 := a_temp1
+		save v4
+
+		a_temp += 4
+		a_counter += -1
+	if a_counter != 0 then again
 
 	plane 3
 	scroll-down 1

--- a/game.ch8
+++ b/game.ch8
@@ -158,13 +158,13 @@
 	pop
 ;
 
-: f_moveSpears
+: f_moveSpearsV
 	push
 	i := spear1
 	load v4
 
-	a_spearX += a_spearSpeedX
 	a_spearSpeedY += c_spearGravityStrength
+	if a_spearSpeedX == 0 then a_spearSpeedY := 0  # stick spear in walls
 	a_spearY += a_spearSpeedY
 	f_drawSpear
 
@@ -236,7 +236,7 @@
 	f_setup
 	loop
 		f_checkScrolling
-		f_moveSpears
+		f_moveSpearsV
 		f_gravity
 		f_checkCollisionV
 		f_input
@@ -403,10 +403,10 @@
 : f_checkCollisionH
 	push
 
+	# check player collisions
 	i := player
 	load v6
 
-	# parameters for collision detection
 	v7 := a_playerX
 	v8 := a_playerY
 	v9 := a_playerSpeedX
@@ -419,6 +419,21 @@
 	i := player
 	save v6
 
+	# check spear collisions
+	i := spear1
+	load v4
+
+	v7 := a_spearX
+	v8 := a_spearY
+	v9 := a_spearSpeedX
+	va := 1
+	f_checkCollisionH_detectCollision
+
+	a_spearX := v7
+	a_spearY := v8
+	a_spearSpeedX := v9
+	i := spear1
+	save v4
 	pop
 ;
 
@@ -472,6 +487,9 @@
 	# sets vf to 1 if the player has hit a step, else sets vf to 0
 	# assumes player position is loaded into a_playerX and a_playerY and
 	# player direction is stored in a_temp
+
+	# don't bother with stepping for spears
+	if a_spriteTableOffset == 1 then jump j_checkCollisionH_checkStep_false
 
 	# store x-offset from player origin to check foot collision
 	#   (based on direction player is moving)

--- a/game.ch8
+++ b/game.ch8
@@ -125,22 +125,21 @@
 	# initialize a spear at the player's location
 	i := player
 	load a_playerX - a_playerDirection
-	va := a_playerX
-	vb := a_playerY
-	vc := a_playerDirection
+	a_temp := a_playerX
 
-	if vc == 0 then va += -2
-	if vc == 1 then va +=  3
+	if a_playerDirection == 0 then a_temp += -2
+	if a_playerDirection == 1 then a_temp +=  3
 
-	a_spearX := va
-	a_spearY := vb
+	a_spearX := a_temp
+	a_spearY := a_playerY
 
 	# initialize spear speed
-	a_spearSpeedX := 0
-	a_temp := c_spearInitialX
-	if vc == 0 then a_spearSpeedX -= a_temp
-	if vc == 1 then a_spearSpeedX += a_temp
+	a_temp := 0
+	a_temp1 := c_spearInitialX
+	if a_playerDirection == 0 then a_temp -= a_temp1
+	if a_playerDirection == 1 then a_temp += a_temp1
 
+	a_spearSpeedX := a_temp
 	a_spearSpeedY := c_spearInitialY
 	a_spearTimer  := c_spearTime
 

--- a/game.ch8
+++ b/game.ch8
@@ -456,6 +456,12 @@
 #  Collision Detection
 #
 
+:alias a_spriteX           v7
+:alias a_spriteY           v8
+:alias a_spriteSpeedX      v9
+:alias a_spriteSpeedY      v9
+:alias a_spriteTableOffset va
+
 : spriteTable
 	i := amy
 	sprite a_spriteX a_spriteY 3
@@ -519,10 +525,10 @@
 	#   it collides. if it ever does, revert back one position and exit.
 	#
 	# input parameters:
-	:alias a_spriteX           v7
-	:alias a_spriteY           v8
-	:alias a_spriteSpeedX      v9
-	:alias a_spriteTableOffset va
+	#   v7 -> a_spriteX
+	#   v8 -> a_spriteY
+	#   v9 -> a_spriteSpeedX
+	#   va -> a_spriteTableOffset
 
 	if a_spriteSpeedX == 0  then return
 	if a_spriteSpeedX < 128 then a_temp :=  1
@@ -668,10 +674,10 @@
 	#   sets vf to 0 if there is no collision, sets vf to 1 if there is
 	#
 	# input parameters:
-	:alias a_spriteX           v7
-	:alias a_spriteY           v8
-	:alias a_spriteSpeedY      v9
-	:alias a_spriteTableOffset va
+	#   v7 -> a_spriteX
+	#   v8 -> a_spriteY
+	#   v9 -> a_spriteSpeedY
+	#   va -> a_spriteTableOffset
 	:alias a_partialDY         vb
 
 	# a_temp is the direction the player is traveling

--- a/game.ch8
+++ b/game.ch8
@@ -158,21 +158,6 @@
 	pop
 ;
 
-: f_moveSpearsV
-	push
-	i := spear1
-	load v4
-
-	a_spearSpeedY += c_spearGravityStrength
-	if a_spearSpeedX == 0 then a_spearSpeedY := 0  # stick spear in walls
-	a_spearY += a_spearSpeedY
-	f_drawSpear
-
-	i := spear1
-	save v4
-	pop
-;
-
 
 #################################
 #
@@ -236,7 +221,7 @@
 	f_setup
 	loop
 		f_checkScrolling
-		f_moveSpearsV
+		f_redrawSprites
 		f_gravity
 		f_checkCollisionV
 		f_input
@@ -454,12 +439,12 @@
 
 	a_counter := a_spriteSpeedX
 	loop	
-		f_checkCollisionH_drawSprite # undraw
+		f_checkCollision_drawSprite # undraw
 		a_counter -= a_temp
 		a_spriteX += a_temp
-		f_checkCollisionH_drawSprite # redraw
+		f_checkCollision_drawSprite # redraw
 		if vf != 0 begin
-			f_checkCollisionH_drawSprite
+			f_checkCollision_drawSprite
 
 			push
 			f_checkCollisionH_checkStep
@@ -472,13 +457,13 @@
 			# if not a step, force the sprite back
 			a_spriteSpeedX := 0
 			a_spriteX -= a_temp
-			f_checkCollisionH_drawSprite
+			f_checkCollision_drawSprite
 			return
 
 			: j_checkCollisionH_detectCollision_step
 			# redraw player 1 higher
 			a_spriteY += -1
-			f_checkCollisionH_drawSprite
+			f_checkCollision_drawSprite
 		end
 	if a_counter != 0 then again
 ;
@@ -528,7 +513,7 @@
 	vf := 0
 ;
 
-: f_checkCollisionH_drawSprite
+: f_checkCollision_drawSprite
 	push
 	v0 <<= a_spriteTableOffset
 	v0 <<= v0
@@ -550,24 +535,74 @@
 
 : f_gravity
 	push
+
+	# player gravity
 	i := player
 	load v6
-
 	a_playerSpeedY += c_gravityStrength
-
 	i := player
 	save v6
+
+	# spear gravity
+	i := spear1
+	load v4
+	a_spearSpeedY += c_spearGravityStrength
+	if a_spearSpeedX == 0 then a_spearSpeedY := 0  # stick spear in walls
+	i := spear1
+	save v4
+
 	pop
 ;
 
 : f_checkCollisionV
-	:alias a_partialDY v7
-
 	push
+
+	# check player collisions
 	i := player
 	load v6
 
-	f_drawAmy
+	v7 := a_playerX
+	v8 := a_playerY
+	v9 := a_playerSpeedY
+	va := 0
+	f_checkCollisionV_detectCollision
+
+	a_playerX := v7
+	a_playerY := v8
+	a_playerSpeedY := v9
+	i := player
+	save v6
+
+	# check spear collisions
+	i := spear1
+	load v4
+
+	v7 := a_spearX
+	v8 := a_spearY
+	v9 := a_spearSpeedY
+	va := 1
+	f_checkCollisionV_detectCollision
+
+	a_spearX := v7
+	a_spearY := v8
+	a_spearSpeedY := v9
+	i := spear1
+	save v4
+
+	pop
+;
+
+: f_checkCollisionV_detectCollision
+	# collide slowly
+	#   undraw sprite and redraw one pixel in the x direction and see if
+	#   it collides. if it ever does, revert back one position and exit.
+	#
+	# input parameters:
+	:alias a_spriteX           v7
+	:alias a_spriteY           v8
+	:alias a_spriteSpeedY      v9
+	:alias a_spriteTableOffset va
+	:alias a_partialDY         vb
 
 	# a_temp is the direction the player is traveling
 
@@ -578,44 +613,37 @@
 
 	# < 128 is (probably) positive and > 128 is (probably) negative
 
-	if a_playerSpeedY < 128 begin
+	if a_spriteSpeedY < 128 begin
 		a_temp := 1
-		a_partialDY >>= a_playerSpeedY
+		a_partialDY >>= a_spriteSpeedY
 		a_partialDY >>= a_partialDY
 	end 
 
-	if a_playerSpeedY > 128 begin
+	if a_spriteSpeedY > 128 begin
 		a_temp := -1
-		a_partialDY >>= a_playerSpeedY
+		a_partialDY >>= a_spriteSpeedY
 		a_partialDY >>= a_partialDY
 		a_partialDY += 0b11000000
 	end
 	
-	if a_partialDY == 0 then jump j_checkCollisionV_return
+	if a_partialDY == 0 then return
 
-	# collide slowly-
-	# undraw amy, redraw amy one pixel in the y direction and see if she collides
-	# if she ever does, revert back one position and exit
-	
 	loop	
-		f_drawAmy
+		f_checkCollision_drawSprite
 		a_partialDY -= a_temp
-		a_playerY += a_temp
-		f_drawAmy
+		a_spriteY += a_temp
+		f_checkCollision_drawSprite
 		if vf != 0 begin
-			if a_temp == 1 then a_playerJumpAvailable := 2
-			a_playerSpeedY := 0
-			f_drawAmy
-			a_playerY -= a_temp
-			f_drawAmy
-			jump j_checkCollisionV_return
+			if a_spriteTableOffset == 0 begin
+				if a_temp == 1 then a_playerJumpAvailable := 2
+			end
+			a_spriteSpeedY := 0
+			f_checkCollision_drawSprite
+			a_spriteY -= a_temp
+			f_checkCollision_drawSprite
+			return
 		end
 	if a_partialDY != 0 then again
-
-: j_checkCollisionV_return
-	i := player
-	save v6
-	pop
 ;
 
 : f_tickCooldowns
@@ -641,6 +669,17 @@
 
 : f_clearSprites
 	# undraw all dynamic sprites before the screen scroll
+	i := player
+	load a_playerX - a_playerY
+	f_drawAmy
+
+	i := spear1
+	load a_spearX - a_spearY
+	f_drawSpear
+;
+
+: f_redrawSprites
+	# redraws all dynamic sprites after the screen scroll
 	i := player
 	load a_playerX - a_playerY
 	f_drawAmy

--- a/game.ch8
+++ b/game.ch8
@@ -122,11 +122,6 @@
 : f_throwSpear
 	push
 
-	# set the spear cooldown
-	i  := spearCooldown
-	v0 := c_spearCooldown
-	save v0
-
 	# initialize a spear at the player's location
 	i := player
 	load a_playerX - a_playerDirection
@@ -149,12 +144,23 @@
 	a_spearSpeedY := c_spearInitialY
 	a_spearTimer  := c_spearTime
 
+	f_drawSpear
+	if vf != 1 then jump j_throwSpear_succeed
+	# if the spear would spawn in a wall, we can't throw it
+	f_drawSpear
+	jump j_throwSpear_fail
+
+: j_throwSpear_succeed
 	# save spear
 	i := spear1
 	save v5
 
-	f_drawSpear
+	# set the spear cooldown
+	i  := spearCooldown
+	v0 := c_spearCooldown
+	save v0
 
+: j_throwSpear_fail
 	pop
 ;
 


### PR DESCRIPTION
Alright, this is a pretty complicated update so hopefully I can explain it clearly enough here.

## Spear Data

Spear data is stored in 5 bytes:
* x location
* y location
* x speed
* y speed
* active flag

The active flag is used to determine whether or not the spear is still on the screen. if the spear doesn't hit anything and falls off the bottom of the screen, then it is deactivated. this flag should also be used if a spear hits an enemy. it indicates that the spear has been destroyed and that it should no longer be rendered on the screen.

## Spear Initialization

When the player presses 'e' the game spawns a spear to the left or right of player (depending on their direction). The spear has a default x and 7 speed defined by constants that we can tweak to our liking. I wanted to spear the have a toss to it so it starts by going up a little bit. With an x velocity of 5 it covers distance pretty well before falling off and I'm pretty happy with it. After a spear is made, a global cooldown time is started that prevents the player from throwing another spear. This is currently set to 40 frames (2 seconds). The main goal here is to have the cooldown be long enough to ensure that the previously thrown spear **must have stopped moving through a collision or exiting the screen** before another spear can be thrown. This allows us to only have to perform collision detection on one spear at a time and prevents us from having to deal with two moving spears somehow colliding.

If the spear would spawn inside a wall or platform, then nothing happens. A new spear is not created, the spear queue is not shifted, and the spear cooldown is not triggered.

## The Spear Queue

There are 3 separate spears that can be on the screen, represented by the queue of `spear1`,  `spear2`, and `spear3`. When a new spear is thrown, the queue shifts down - spear3 is removed from the queue and undrawn, then spear 2 is moved to spear3, spear1 is moved to spear2, and the new spear become spear1. It's important the new spear is spear1 because that spear is assumed to potentially be traveling and so we perform collision detection on it (and it alone).

Currently there can be gaps in the queue. If the first spear hits a wall, the second spear falls off the bottom of the screen, and then the third spear hits. When the player throws a fourth spear the first spear will despawn, even though there are only 2 spears on the screen when the fourth in created. We can solve this with a more sophisticated queue algorithm.

## Collision Detection Updates

Here's the big whammy. Since spears are affected by gravity and also moving more than 1 pixel per frame horizontally, the same multi-step collision detection is used for them as well as the player. Rather than duplicating all that code I generalized the collision detection loop in two new subroutines, `f_checkCollisionH_detectCollision` and `f_checkCollisionV_detectCollision`. These take 'parameters' by assigning v7-va and then mutating them. This allows these subroutines to work on different data structures by only modify the values that they need.

The subroutine is able to generalize which sprite is drawn by an additional parameter which is the offset for a spriteTable. Currently 0 is the player and 1 is a spear.

Unfortunately this means that we can load in data structures that are more than 7 bytes (at least for collision detection).

### Edge Cases

1. Since the stepping algorithm needs to know how many jumps a player has left, it reads the value directly from `a_playerJumpAvailable`. This is sloppy but I didn't have room to pass another argument into the function.

2. Since we don't want spears to slide up slopes, stepping is conditionally avoided for the specific sprite. Land-walking enemies will want to take advantage of this. Perhaps we can set them to 'have a jump available' even though they don't jump in order to satisfy this predicate.

3. For vertical collisions, the game resotres jumps to the player if they are on the ground. This check is only done for the player (aka, if the spriteTable offset passed to the vertical collision subroutine is 0)

### No more subpixel x movement

It seemed like we never really needed to take advantage of sub-pixel x values, as they just felt slow and unresponsive. To simplify the calculation and values I took them out. I've adjusted the player speed values to reflect this.